### PR TITLE
Fixes issue #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,13 @@ That will download all the necessary dependencies.
 
 #### Checkpoint 1: _Run_ the _Tests_!
 
+In your terminal, go into the newly created app folder using:
 
-In your terminal, run the following `mix` command:
+```sh
+cd live_view_counter
+```
+
+And then run the following `mix` command:
 
 ```sh
 mix test


### PR DESCRIPTION
Fixes issue #22 by adding an extra instruction in the 'Checkpoint 1: Run the Tests!' section, to cd into the app folder before running the tests.
Added instruction:

In your terminal, go into the newly created app folder using:

```sh
cd live_view_counter
```